### PR TITLE
Update Request Signing examples

### DIFF
--- a/dotnet/Program.cs
+++ b/dotnet/Program.cs
@@ -15,13 +15,14 @@ namespace request_signer
             var body = new
             {
                 codes = new[] { "8888888888888888" },
-                currencyCode = "EUR",
+                currencyCode = "CHF",
                 amount = 8,
-                channelId = "ecommerce",
-                transactionReference = "ABC",
-                deviceReference = "539e5805-b2eb-4ac5-9e5e-45ec0524172e",
-                integratorReference = "456",
-                consumerPaymentMethod = "card"
+                channelId = "9b05145f-c50d-4cd6-ac03-86f9f4e9fbbf",
+                merchantUserReference = "john.doe@johndoe.com",
+                merchantTransactionReference = "100000000010",
+                integratorTransactionReference = "7fd113c",
+                pspTransactionReference = "e5785e77e",
+                deviceReference = "539e5805-b2eb-4ac5-9e5e-45ec0524172e"
             };
 
             string requestBody = JsonSerializer.Serialize(body);
@@ -54,7 +55,7 @@ namespace request_signer
             System.Console.WriteLine();
             System.Console.WriteLine("And signing with the private key in " + privateKeyPath);
             System.Console.WriteLine();
-            System.Console.WriteLine("Set the Shared-Key header to:");
+            System.Console.WriteLine("Set the Request-Signature header to:");
             System.Console.WriteLine(base64EncodedSignature);
         }
     }

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -7,13 +7,14 @@ const readFile = promisify(fs.readFile);
 const privateKeyPath = "../example.private.key.pem";
 const body = {
   codes: ["8888888888888888"],
-  currencyCode: "EUR",
+  currencyCode: "CHF",
   amount: 8,
-  channelId: "ecommerce",
-  transactionReference: "ABC",
+  channelId: "9b05145f-c50d-4cd6-ac03-86f9f4e9fbbf",
+  merchantUserReference: "john.doe@johndoe.com",
+  merchantTransactionReference: "100000000010",
+  integratorTransactionReference: "7fd113c",
+  pspTransactionReference: "e5785e77e",
   deviceReference: "539e5805-b2eb-4ac5-9e5e-45ec0524172e",
-  integratorReference: "456",
-  consumerPaymentMethod: "card",
 };
 
 (async () => {
@@ -35,6 +36,6 @@ const body = {
   console.log();
   console.log(`And signing with the private key in ${privateKeyPath}`);
   console.log();
-  console.log("Set the Shared-Key header to:");
+  console.log("Set the Request-Signature header to:");
   console.log(base64EncodedSignature);
 })();

--- a/php/index.php
+++ b/php/index.php
@@ -5,13 +5,14 @@
 $private_key_path = "../example.private.key.pem";
 $body = [
     "codes" => ["8888888888888888"],
-    "currencyCode" => "EUR",
+    "currencyCode" => "CHF",
     "amount" => 8,
-    "channelId" => "ecommerce",
-    "transactionReference" => "ABC",
+    "channelId" => "9b05145f-c50d-4cd6-ac03-86f9f4e9fbbf",
+    "merchantUserReference" => "john.doe@johndoe.com",
+    "merchantTransactionReference" => "100000000010",
+    "integratorTransactionReference" => "7fd113c",
+    "pspTransactionReference" => "e5785e77e",
     "deviceReference" => "539e5805-b2eb-4ac5-9e5e-45ec0524172e",
-    "integratorReference" => "456",
-    "consumerPaymentMethod" => "card"
 ];
 
 // In a production deployment this needs to be stored securely and retrieved
@@ -30,6 +31,6 @@ print($request_body . "\n");
 print("\n");
 print("And signing with the private key in " . $private_key_path . "\n");
 print("\n");
-print("Set the Shared-Key header to:\n");
+print("Set the Request-Signature header to:\n");
 print(base64_encode($binary_signature) . "\n");
 ?>

--- a/python/main.py
+++ b/python/main.py
@@ -14,13 +14,14 @@ private_key_path = "../example.private.key.pem"
 #       Just make sure the string you send to the server is the string you sign.
 body = OrderedDict([
   ("codes", ["8888888888888888"]),
-  ("currencyCode", "EUR"),
+  ("currencyCode", "CHF"),
   ("amount", 8),
-  ("channelId", "ecommerce"),
-  ("transactionReference", "ABC"),
-  ("deviceReference", "539e5805-b2eb-4ac5-9e5e-45ec0524172e"),
-  ("integratorReference", "456"),
-  ("consumerPaymentMethod", "card"),
+  ("channelId", "9b05145f-c50d-4cd6-ac03-86f9f4e9fbbf"),
+  ("merchantUserReference", "john.doe@johndoe.com"),
+  ("merchantTransactionReference", "100000000010"),
+  ("integratorTransactionReference", "7fd113c"),
+  ("pspTransactionReference", "e5785e77e"),
+  ("deviceReference", "539e5805-b2eb-4ac5-9e5e-45ec0524172e")
 ])
 
 # In a production deployment this needs to be stored securely and retrieved
@@ -40,5 +41,5 @@ print(request_body)
 print("\n")
 print("And signing with the private key in " + private_key_path)
 print("\n")
-print("Set the Shared-Key header to:")
+print("Set the Request-Signature header to:")
 print(base64.b64encode(signature).decode())

--- a/ruby/main.rb
+++ b/ruby/main.rb
@@ -6,13 +6,14 @@ require 'openssl'
 private_key_path = "../example.private.key.pem";
 body = {
     :codes => ["8888888888888888"],
-    :currencyCode => "EUR",
+    :currencyCode => "CHF",
     :amount => 8,
-    :channelId => "ecommerce",
-    :transactionReference => "ABC",
+    :channelId => "9b05145f-c50d-4cd6-ac03-86f9f4e9fbbf",
+    :merchantUserReference => "john.doe@johndoe.com",
+    :merchantTransactionReference => "100000000010",
+    :integratorTransactionReference => "7fd113c",
+    :pspTransactionReference => "e5785e77e",
     :deviceReference => "539e5805-b2eb-4ac5-9e5e-45ec0524172e",
-    :integratorReference => "456",
-    :consumerPaymentMethod => "card"
 };
 
 # In a production deployment this needs to be stored securely and retrieved
@@ -30,5 +31,5 @@ puts request_body
 puts 
 puts "And signing with the private key in " + private_key_path
 puts 
-puts "Set the Shared-Key header to:"
+puts "Set the Request-Signature header to:"
 puts Base64.encode64 signature


### PR DESCRIPTION
Updated request signing examples to match latest API body format, and fixed name of header to set that's logged.